### PR TITLE
Fixing cache capacity leak

### DIFF
--- a/core.js
+++ b/core.js
@@ -48,6 +48,7 @@ LRUCache.prototype.put = function (key, value) {
   this.tail = entry
   if (this.size === this.limit) {
     // we hit the limit -- remove the head
+    this.size++
     return this.shift()
   } else {
     // increase the size counter

--- a/test.js
+++ b/test.js
@@ -84,5 +84,22 @@ assert.deepEqual(c.shift(), { key: 0, value: 3, newer: undefined, older: undefin
 assert.deepEqual(c.shift(), { key: 0, value: 4, newer: undefined, older: undefined })
 assert.equal(c.size, 0) // check .size correct
 c.forEach(function () { assert(false) }, undefined, true)  // check .tail correct
+
+// test fixed capacity
+c = new LRUCache(2)
+
+c.put('one', 1)
+c.put('two', 2)
+c.put('three', 3)
+c.put('four', 4)
+c.put('five', 5)
+c.put('six', 6)
+c.put('seven', 7)
+c.put('eight', 8)
+
+assert.strictEqual(c.size, 2)
+assert.strictEqual(c.limit, 2)
+assert.strictEqual(Object.keys(c._keymap).length, 2)
+
 // If we made it down here, all tests passed. Neat.
 console.log('All tests passed!')


### PR DESCRIPTION
Hello @Empact. The cache seems to leak memory by storing keys beyond the desired capacity. This seems to be because the size of the cache is decreased but not increased back when shifting on a put that overflows the capacity. This PR proposes a fix and adds new tests to reflect this.

Have a good day.